### PR TITLE
Hide lessons' placeholders

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -84,8 +84,10 @@
         <div id="drop-area" class="border mt-3 p-5 text-center" disabled>
             Drag and drop HEX file here
         </div>
-        <h2 class="my-4">Available lessons:</h1>
-        <div id="lessonsContainer"></div>
+        <div class="d-none">
+            <h2 class="my-4">Available lessons:</h2>
+            <div id="lessonsContainer"></div>
+        </div>        
     </div>
     <!-- Modal -->
     <div class="modal fade" id="dataModal" tabindex="-1" role="dialog" aria-labelledby="dataModalLabel" aria-hidden="true">


### PR DESCRIPTION
lessons' placeholders are now hidden.
When the lessons are available they will be displayed