### PR TITLE
fix handling no EEPROM

### DIFF
--- a/www/js/pic/icsp_hid.js
+++ b/www/js/pic/icsp_hid.js
@@ -91,8 +91,8 @@ class ICSP_HID {
 
         console.log('Get contents of EEPROM: setPC 0xF000');     
         let eepromAddress = this.getEEPROMAddress();
-        let eeprom = null;
-        if(eepromAddress != null) {
+        let eeprom = [];
+        if(eepromAddress != null && this.EESIZ != 0) {
             await this.setPC(eepromAddress * 2);
             eeprom = await this.readWordBlock(this.EESIZ);    
         }


### PR DESCRIPTION
When reading devices without EEPROM, we get the EEPROM address defined on the PIC-Family class and the EEPROM size stored on the PIC memory. When displaying the data, we got an Address but with 0 size. This condition is now added on the reading procedure.